### PR TITLE
Increase connection pool to avoid warning

### DIFF
--- a/sdk/diffgram/core/core.py
+++ b/sdk/diffgram/core/core.py
@@ -33,6 +33,9 @@ class Project():
 		):
 
 		self.session = requests.Session()
+		adapter = requests.adapters.HTTPAdapter(pool_connections = 30, pool_maxsize = 30)
+		self.session.mount('http://', adapter)
+		self.session.mount('https://', adapter)
 		self.project_string_id = None
 
 		self.debug = debug


### PR DESCRIPTION
It seems that adding a custom adapter with a bigger pool removes the warning completely with no need to change loglevels to this case