### PR TITLE
fix: function get_http_auth() is on self object not self.client

### DIFF
--- a/sdk/diffgram/file/view.py
+++ b/sdk/diffgram/file/view.py
@@ -48,7 +48,7 @@ def get_label_file_dict(self, use_session = True):
         # Add Auth
         response = requests.get(self.host + endpoint,
                                 headers = {'directory_id': str(self.directory_id)},
-                                auth = self.client.get_http_auth())
+                                auth = self.get_http_auth())
 
     self.handle_errors(response)
 


### PR DESCRIPTION
self in this context is already the client so no need for the extra call to client.